### PR TITLE
fixed DataConstants namespace in GenerateMenu page

### DIFF
--- a/Features/GenerateMenu.md
+++ b/Features/GenerateMenu.md
@@ -32,7 +32,7 @@ public class GenerateDisposeItemProvider : IGenerateActionProvider
 {
   public IEnumerable<IGenerateActionWorkflow> CreateWorkflow(IDataContext dataContext)
   {
-    var solution = dataContext.GetData(IDE.DataConstants.SOLUTION);
+    var solution = dataContext.GetData(ProjectModel.DataContext.DataConstants.SOLUTION);
     var iconManager = solution.GetComponent<PsiIconManager>();
     var icon = iconManager.GetImage(CLRDeclaredElementType.METHOD);
     yield return new GenerateDisposeActionWorkflow(icon);
@@ -73,7 +73,7 @@ Now, all is good but the above won’t work. The problem is that we’ve defined
 ```csharp
 public override bool IsAvailable(IDataContext dataContext)
 {
-  var solution = dataContext.GetData(IDE.DataConstants.SOLUTION);
+  var solution = dataContext.GetData(ProjectModel.DataContext.DataConstants.SOLUTION);
   if (solution == null)
     return false;
 


### PR DESCRIPTION
Fixed the `DataConstants` namespace in the GenerateMenu example code.

This is the correct namespace for the latest nuget release: `JetBrains.ProjectModel.DataContext.DataConstants.SOLUTION`
